### PR TITLE
add support for json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +201,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -277,6 +301,7 @@ version = "0.1.4"
 dependencies = [
  "clap",
  "colored",
+ "serde_json",
  "thiserror",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "tomlq"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tomlq"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "Natalia Maximo <iam@natalia.dev>",
     "James Munns <james.munns@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,17 @@ toml = "0.8"
 clap = { version = "4.5", features = ["derive", "usage", "help"] }
 thiserror = "1.0.61"
 colored = { version = "2.1.0", optional = true }
+serde_json = { version = "1.0.120", features = [
+    "indexmap",
+    "preserve_order",
+    "raw_value",
+    "unbounded_depth",
+], optional = true }
 
 [features]
-default = []
+default = ["json"]
 color = ["colored"]
+json = ["dep:serde_json"]
 
 
 [lib]

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -29,6 +29,7 @@ fn main() {
         Ok(needle) => {
             match app.output {
                 OutputType::Toml => println!("{}", format!("{}", needle).trim_matches('"')),
+                #[cfg(feature = "json")]
                 OutputType::Json => println!("{}", serde_json::to_string(&needle).unwrap()),
             }
             0

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
 use std::process::exit;
+use tq::OutputType;
 
 fn main() {
     eprintln!(
@@ -9,7 +10,7 @@ fn main() {
     );
     eprintln!(
         "{}",
-        "The \"tomlq\" binary will be removed from this package starting in version 0.2.0".yellow()
+        "The \"tomlq\" binary will be removed from this package starting in version 0.2.0, scheduled for January 1, 2025".yellow()
     );
 
     let app = tq::Cli::parse();
@@ -26,7 +27,10 @@ fn main() {
 
     exit(match x {
         Ok(needle) => {
-            println!("{}", format!("{}", needle).trim_matches('"'));
+            match app.output {
+                OutputType::Toml => println!("{}", format!("{}", needle).trim_matches('"')),
+                OutputType::Json => println!("{}", serde_json::to_string(&needle).unwrap()),
+            }
             0
         }
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,14 @@ pub enum TqError {
     PatternNotFoundError { pattern: String },
 }
 
+#[derive(Default, Debug, Clone, clap::ValueEnum)]
+pub enum OutputType {
+    #[default]
+    Toml,
+    #[cfg(feature = "json")]
+    Json,
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
@@ -28,12 +36,19 @@ pub struct Cli {
 
     /// Field to read from the TOML file
     pub pattern: String,
-    // /// The TOML File URL to read
-    // #[arg(short, long, value_name = "URL_PATH")]
-    // pub url: String,
+
+    /// The output type. Default is TOML, but supports outputting in different formats.
+    #[arg(short, long, value_name = "OUTPUT_TYPE", default_value = "toml")]
+    pub output: OutputType,
 }
 
 pub fn extract_pattern<'a>(toml_file: &'a Value, pattern: &str) -> Result<&'a Value> {
+    if pattern.is_empty() || pattern == "." {
+        return Ok(toml_file);
+    }
+
+    let pattern = pattern.trim_start_matches('.');
+
     pattern
         .split('.')
         .fold(Some(toml_file), |acc, key| match acc {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::process::exit;
+use tq::OutputType;
 
 fn main() {
     let app = tq::Cli::parse();
@@ -16,7 +17,11 @@ fn main() {
 
     exit(match x {
         Ok(needle) => {
-            println!("{}", format!("{}", needle).trim_matches('"'));
+            match app.output {
+                OutputType::Toml => println!("{}", format!("{}", needle).trim_matches('"')),
+                OutputType::Json => println!("{}", serde_json::to_string(&needle).unwrap()),
+            }
+
             0
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
         Ok(needle) => {
             match app.output {
                 OutputType::Toml => println!("{}", format!("{}", needle).trim_matches('"')),
+                #[cfg(feature = "json")]
                 OutputType::Json => println!("{}", serde_json::to_string(&needle).unwrap()),
             }
 


### PR DESCRIPTION
Adding support for the full scope of what `jq` can do will be an extremely difficult process that will likely take a few months of work on my end to even get close. However, exporting the `toml` document as a `json` string that can be consumed by `jq` is a lot simpler!

This feature allows users to chain output from `tq` into `jq`, and leverage the existing capabilities of that tool.