### PR TITLE
make 'color' an optional feature for building the legacy binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ test = false
 name = "tomlq"
 path = "src/legacy.rs"
 test = false
-required-features = ["color"]
 
 [package.metadata.binstall]
 pkg-fmt = "tgz"

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,17 +1,21 @@
 use clap::Parser;
+#[cfg(feature = "color")]
 use colored::Colorize;
 use std::process::exit;
 use tq::OutputType;
 
 fn main() {
-    eprintln!(
-        "{}",
-        "You are currently using the legacy version of tomlq. Please use the new binary \"tq\" instead.".yellow()
-    );
-    eprintln!(
-        "{}",
-        "The \"tomlq\" binary will be removed from this package starting in version 0.2.0, scheduled for January 1, 2025".yellow()
-    );
+    let warning = "You are currently using the legacy version of tomlq. Please use the new binary \"tq\" instead.";
+    let deprecation = "The \"tomlq\" binary will be removed from this package starting in version 0.2.0, scheduled for January 1, 2025";
+
+    #[cfg(feature = "color")]
+    let warning = warning.yellow();
+
+    #[cfg(feature = "color")]
+    let deprecation = deprecation.yellow();
+
+    eprintln!("{}", warning,);
+    eprintln!("{}", deprecation);
 
     let app = tq::Cli::parse();
 


### PR DESCRIPTION
fixes #11 to prevent regression for installs that don't use any features