### PR TITLE
bump version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "tomlq"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tomlq"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     "Natalia Maximo <iam@natalia.dev>",
     "James Munns <james.munns@gmail.com>",


### PR DESCRIPTION
updates the version, which was missing from #12 so this can be released to Cargo to properly fix #11 