### PR TITLE
Cleanup codebase and increment version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "tomlq"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "tomlq"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "tomlq"
-version = "0.1.6"
+version = "0.2.0"
 authors = [
     "Natalia Maximo <iam@natalia.dev>",
     "James Munns <james.munns@gmail.com>",
+    "Venus Xeon-Blonde <venus@venusblon.de>"
 ]
 edition = "2021"
 license = "MIT"
@@ -15,18 +16,21 @@ toml = "0.8"
 clap = { version = "4.5", features = ["derive", "usage", "help"] }
 thiserror = "1.0.61"
 colored = { version = "2.1.0", optional = true }
-serde_json = { version = "1.0.120", features = [
+
+[dependencies.serde_json] 
+version = "1.0.120"
+features = [
     "indexmap",
     "preserve_order",
     "raw_value",
     "unbounded_depth",
-], optional = true }
+]
+optional = true
 
 [features]
 default = ["json"]
 color = ["colored"]
 json = ["dep:serde_json"]
-
 
 [lib]
 name = "tq"
@@ -36,12 +40,10 @@ doctest = false
 
 [[bin]]
 name = "tq"
-path = "src/main.rs"
 test = false
 
 [[bin]]
 name = "tomlq"
-path = "src/legacy.rs"
 test = false
 
 [package.metadata.binstall]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "tomlq"
-version = "0.2.0"
+version = "0.1.6"
 authors = [
     "Natalia Maximo <iam@natalia.dev>",
     "James Munns <james.munns@gmail.com>",
-    "Venus Xeon-Blonde <venus@venusblon.de>"
 ]
 edition = "2021"
 license = "MIT"

--- a/src/bin/tomlq.rs
+++ b/src/bin/tomlq.rs
@@ -1,3 +1,5 @@
+//! Legacy tomlq binary.
+
 use clap::Parser;
 #[cfg(feature = "color")]
 use colored::Colorize;

--- a/src/bin/tq.rs
+++ b/src/bin/tq.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
-use std::process::exit;
+use std::process::ExitCode;
 use tq::OutputType;
 
-fn main() {
+fn main() -> ExitCode {
     let app = tq::Cli::parse();
 
     let toml_file = tq::load_toml_from_file(&app.file);
@@ -10,12 +10,12 @@ fn main() {
     let Ok(toml_file) = toml_file else {
         let e = toml_file.unwrap_err();
         eprintln!("{}", e);
-        exit(-1);
+        return ExitCode::FAILURE;
     };
 
     let x = tq::extract_pattern(&toml_file, &app.pattern);
 
-    exit(match x {
+    match x {
         Ok(needle) => {
             match app.output {
                 OutputType::Toml => println!("{}", format!("{}", needle).trim_matches('"')),
@@ -23,11 +23,11 @@ fn main() {
                 OutputType::Json => println!("{}", serde_json::to_string(&needle).unwrap()),
             }
 
-            0
+            ExitCode::SUCCESS
         }
         Err(e) => {
             eprintln!("{}", e);
-            -1
+            ExitCode::FAILURE
         }
-    });
+    }
 }


### PR DESCRIPTION
Use `std::process::ExitCode` rather than `std::process::exit`.

Expect more pull requests coming from me soon