### PR TITLE
feat: add write support behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,69 +1,73 @@
-[package]
-name = "tomlq"
-version = "0.2.2"
-authors = [
-    "Natalia Maximo <iam@natalia.dev>",
-    "James Munns <james.munns@gmail.com>",
-]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/cryptaliagy/tomlq"
-description = "A tool for obtaining information from a TOML file on the command line"
-
-[dependencies]
-toml = "0.8"
-clap = { version = "4.5", features = [
-    "derive",
-    "usage",
-    "help",
-], optional = true }
-colored = { version = "3.0.0", optional = true }
-thiserror = "2.0.11"
-console = { version = "0.15.10", features = [
-    "windows-console-colors",
-], optional = true }
-anyhow = { version = "1.0.95", features = ["backtrace"], optional = true }
-bat = { version = "0.25.0", optional = true, default-features = false, features = [
-    "build-assets",
-    "regex-fancy",
-] }
-serde = "1.0.217"
-
-
-[dependencies.serde_json]
-version = "1.0.135"
-features = ["indexmap", "preserve_order", "raw_value", "unbounded_depth"]
-optional = true
-
-[features]
-default = ["json", "bin"]
-json = ["dep:serde_json"]
-# Syntax highlighting feature for the tq CLI -- optional, disabled by default.
-syntax-highlighting = ["bin", "dep:bat", "dep:console"]
-bin = ["dep:clap", "dep:anyhow"]
-
-# THIS FEATURE IS FOR THE PREVIOUS VERSION OF TOMLQ AND IS NOT USED BY THE TQ BINARY.
-# IT WILL BE REMOVED IN A FUTURE RELEASE.
-color = ["dep:colored"]
-
-[lib]
-name = "tq"
-test = true
-doctest = true
-doc = true
-
 [[bin]]
 name = "tq"
-test = false
 required-features = ["bin"]
+test = false
+
+[dependencies]
+serde = "1.0.217"
+thiserror = "2.0.11"
+toml = "0.8"
+
+[dependencies.anyhow]
+features = ["backtrace"]
+optional = true
+version = "1.0.95"
+
+[dependencies.bat]
+default-features = false
+features = ["build-assets", "regex-fancy"]
+optional = true
+version = "0.25.0"
+
+[dependencies.clap]
+features = ["derive", "usage", "help"]
+optional = true
+version = "4.5"
+
+[dependencies.colored]
+optional = true
+version = "3.0.0"
+
+[dependencies.console]
+features = ["windows-console-colors"]
+optional = true
+version = "0.15.10"
+
+[dependencies.serde_json]
+features = ["indexmap", "preserve_order", "raw_value", "unbounded_depth"]
+optional = true
+version = "1.0.135"
+
+[features]
+write = []
+bin = ["dep:clap", "dep:anyhow"]
+color = ["dep:colored"]
+default = ["json", "bin"]
+json = ["dep:serde_json"]
+syntax-highlighting = ["bin", "dep:bat", "dep:console"]
+
+[lib]
+doc = true
+doctest = true
+name = "tq"
+test = true
+
+[package]
+authors = ["Natalia Maximo <iam@natalia.dev>", "James Munns <james.munns@gmail.com>"]
+description = "A tool for obtaining information from a TOML file on the command line"
+edition = "2021"
+license = "MIT"
+name = "tomlq"
+repository = "https://github.com/cryptaliagy/tomlq"
+version = "0.2.2"
 
 [package.metadata.binstall]
 pkg-fmt = "tgz"
 
-[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
-
 [package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
 pkg-url = "{ repo }/releases/download/{ version }/{ name }.arm64{ archive-suffix }"
 
 [package.metadata.binstall.overrides.armv7-unknown-linux-gnueabi]
@@ -72,19 +76,19 @@ pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7{ archive-suffix
 [package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
 pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7hf{ archive-suffix }"
 
-[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
-
-[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }.arm64{ archive-suffix }"
-
 [package.metadata.binstall.overrides.armv7-unknown-linux-musleabi]
 pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7{ archive-suffix }"
 
 [package.metadata.binstall.overrides.armv7-unknown-linux-musleabihf]
 pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7hf{ archive-suffix }"
 
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.amd64{ archive-suffix }"
+
 [profile.release]
-strip = true
-opt-level = "z"
 lto = true
+opt-level = "z"
+strip = true

--- a/src/bin/tq.rs
+++ b/src/bin/tq.rs
@@ -6,6 +6,8 @@ use std::{
     path::PathBuf,
 };
 use toml::{ser::ValueSerializer, Value};
+#[cfg(feature = "write")]
+use tq::parse_toml_value;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -34,6 +36,10 @@ struct Cli {
 
     /// Field to read from the TOML file
     pub pattern: String,
+
+    /// Write value to the given pattern
+    #[arg(short = 'w', long = "write")]
+    pub write: Option<String>,
 
     #[cfg(feature = "syntax-highlighting")]
     #[arg(short, long, default_value = "auto")]
@@ -82,7 +88,24 @@ fn main() -> anyhow::Result<()> {
             }
         }
     };
-    let toml_value: toml::Value = toml::from_str(&input_string)?;
+    let mut toml_value: toml::Value = toml::from_str(&input_string)?;
+    // Handle write-mode before extracting pattern (requires mutable access)
+    #[cfg(feature = "write")]
+    if let Some(write_val) = &app.write {
+        let new_val = parse_toml_value(write_val);
+
+        tq::set_pattern(&mut toml_value, &app.pattern, new_val)?;
+
+        let output = toml::to_string(&toml_value)?;
+
+        if let Some(path) = &app.file {
+            std::fs::write(path, output)?;
+        } else {
+            println!("{output}");
+        }
+
+        return Ok(());
+    }
 
     let result: &Value = tq::extract_pattern(&toml_value, &app.pattern)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,55 @@ pub fn extract_pattern<'a>(toml_file: &'a Value, pattern: &str) -> TqResult<&'a 
         })
 }
 
-#[deprecated = 
-    "Users should use/call the similar functions from the `toml` crate going forward. This function will be \
-    removed in a future release"
-]
+#[cfg(feature = "write")]
+pub fn parse_toml_value(s: &str) -> toml::Value {
+    if let Ok(i) = s.parse::<i64>() {
+        toml::Value::Integer(i)
+    } else if let Ok(f) = s.parse::<f64>() {
+        toml::Value::Float(f)
+    } else if let Ok(b) = s.parse::<bool>() {
+        toml::Value::Boolean(b)
+    } else {
+        toml::Value::String(s.to_string())
+    }
+}
+
+#[cfg(feature = "write")]
+pub fn set_pattern(toml: &mut toml::Value, pattern: &str, new_value: toml::Value) -> TqResult<()> {
+    let pattern = pattern.trim_start_matches('.');
+    let mut parts = pattern.split('.').peekable();
+
+    let mut current = toml;
+
+    while let Some(key) = parts.next() {
+        let is_last = parts.peek().is_none();
+
+        if is_last {
+            match current {
+                toml::Value::Table(table) => {
+                    table.insert(key.to_string(), new_value);
+                    return Ok(());
+                }
+                _ => {
+                    return Err(TqError::PatternNotFoundError {
+                        pattern: pattern.to_string(),
+                    });
+                }
+            }
+        } else {
+            current = current
+                .get_mut(key)
+                .ok_or_else(|| TqError::PatternNotFoundError {
+                    pattern: pattern.to_string(),
+                })?;
+        }
+    }
+
+    Ok(())
+}
+
+#[deprecated = "Users should use/call the similar functions from the `toml` crate going forward. This function will be \
+    removed in a future release"]
 pub fn load_toml_from_file(file_name: &str) -> TqResult<toml::Value> {
     let mut file = File::open(file_name).map_err(|e| TqError::FileOpenError {
         file_name: file_name.to_string(),
@@ -104,5 +149,30 @@ mod tests {
         let x = extract_pattern(&toml_file, "package.test").unwrap();
 
         assert_eq!(x, &Value::String("test".to_string()));
+    }
+}
+
+#[cfg(all(test, feature = "write"))]
+mod write_tests {
+    use super::*;
+
+    #[test]
+    fn test_set_pattern() {
+        let mut toml = toml::from_str(
+            r#"
+            [package]
+            version = "0.1.0"
+            "#,
+        )
+        .unwrap();
+
+        set_pattern(
+            &mut toml,
+            "package.version",
+            toml::Value::String("1.2.3".into()),
+        )
+        .unwrap();
+
+        assert_eq!(toml["package"]["version"].as_str().unwrap(), "1.2.3");
     }
 }


### PR DESCRIPTION
I thought it would be useful to add the ability to write values by path.
I've implemented this functionality behind a feature flag (`write`) and covered it with tests.

The existing behavior is unchanged when the feature is disabled.