### PR TITLE
feat: add macOS (arm64/x86_64) builds to CI and releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-binary:
+  build-linux:
     strategy:
       fail-fast: true
       matrix:
@@ -45,6 +45,32 @@ jobs:
 
       - name: Build the binary for the target
         run: cross build --target ${{ matrix.architecture.target }} --release --bins --all-features
+
+  build-macos:
+    strategy:
+      fail-fast: true
+      matrix:
+        architecture:
+          - target: "aarch64-apple-darwin"
+            name: "darwin-arm64"
+            runner: "macos-latest"
+          - target: "x86_64-apple-darwin"
+            name: "darwin-amd64"
+            runner: "macos-13"
+    runs-on: ${{ matrix.architecture.runner }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.architecture.target }}
+
+      - name: Run the tests
+        run: cargo test --release
+
+      - name: Build the binary for the target
+        run: cargo build --target ${{ matrix.architecture.target }} --release --bins --all-features
 
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         name: Output the current version of the project
         run: echo "version=$(tq -f Cargo.toml 'package.version')" >> "$GITHUB_OUTPUT"
 
-  build-binary:
+  build-linux:
     strategy:
       fail-fast: true
       matrix:
@@ -91,10 +91,54 @@ jobs:
           path: |
             ./output/*
 
+  build-macos:
+    strategy:
+      fail-fast: true
+      matrix:
+        architecture:
+          - target: "aarch64-apple-darwin"
+            name: "darwin-arm64"
+            runner: "macos-latest"
+          - target: "x86_64-apple-darwin"
+            name: "darwin-amd64"
+            runner: "macos-13"
+    runs-on: ${{ matrix.architecture.runner }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.architecture.target }}
+
+      - name: Run the tests
+        run: cargo test --release
+
+      - name: Build the binary for the target
+        run: cargo build --target ${{ matrix.architecture.target }} --release --bins --all-features
+
+      - name: Create output directory
+        run: mkdir ./output
+
+      - name: Package binary as tarball
+        run: |
+          mv target/${{ matrix.architecture.target }}/release/${{ env.PACKAGE_NAME }} \
+            ./output/${{ env.PACKAGE_NAME }}
+          tar czvf ./output/tomlq.${{ matrix.architecture.name }}.tgz -C ./output tq
+          rm ./output/tq
+
+      - name: Upload the binary as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}-drop-${{ matrix.architecture.name }}
+          path: |
+            ./output/*
+
   release-binary:
     needs:
       - get-version
-      - build-binary
+      - build-linux
+      - build-macos
       - audit
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,60 +2,13 @@
 name = "tomlq"
 version = "0.2.2"
 authors = [
-    "Natalia Maximo <iam@natalia.dev>",
-    "James Munns <james.munns@gmail.com>",
+  "Natalia Maximo <iam@natalia.dev>",
+  "James Munns <james.munns@gmail.com>",
 ]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/cryptaliagy/tomlq"
 description = "A tool for obtaining information from a TOML file on the command line"
-
-[dependencies]
-toml = "0.8"
-clap = { version = "4.5", features = [
-    "derive",
-    "usage",
-    "help",
-], optional = true }
-colored = { version = "3.0.0", optional = true }
-thiserror = "2.0.11"
-console = { version = "0.15.10", features = [
-    "windows-console-colors",
-], optional = true }
-anyhow = { version = "1.0.95", features = ["backtrace"], optional = true }
-bat = { version = "0.25.0", optional = true, default-features = false, features = [
-    "build-assets",
-    "regex-fancy",
-] }
-serde = "1.0.217"
-
-
-[dependencies.serde_json]
-version = "1.0.135"
-features = ["indexmap", "preserve_order", "raw_value", "unbounded_depth"]
-optional = true
-
-[features]
-default = ["json", "bin"]
-json = ["dep:serde_json"]
-# Syntax highlighting feature for the tq CLI -- optional, disabled by default.
-syntax-highlighting = ["bin", "dep:bat", "dep:console"]
-bin = ["dep:clap", "dep:anyhow"]
-
-# THIS FEATURE IS FOR THE PREVIOUS VERSION OF TOMLQ AND IS NOT USED BY THE TQ BINARY.
-# IT WILL BE REMOVED IN A FUTURE RELEASE.
-color = ["dep:colored"]
-
-[lib]
-name = "tq"
-test = true
-doctest = true
-doc = true
-
-[[bin]]
-name = "tq"
-test = false
-required-features = ["bin"]
 
 [package.metadata.binstall]
 pkg-fmt = "tgz"
@@ -84,7 +37,58 @@ pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7{ archive-suffix
 [package.metadata.binstall.overrides.armv7-unknown-linux-musleabihf]
 pkg-url = "{ repo }/releases/download/{ version }/{ name }.armv7hf{ archive-suffix }"
 
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.darwin-arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }.darwin-amd64{ archive-suffix }"
+
+[lib]
+doc = true
+doctest = true
+name = "tq"
+test = true
+
+[[bin]]
+name = "tq"
+required-features = ["bin"]
+test = false
+
+[dependencies]
+anyhow = { version = "1.0.95", features = ["backtrace"], optional = true }
+bat = { version = "0.25.0", default-features = false, features = [
+  "build-assets",
+  "regex-fancy",
+], optional = true }
+clap = { version = "4.5", features = [
+  "derive",
+  "help",
+  "usage",
+], optional = true }
+colored = { version = "3.0.0", optional = true }
+console = { version = "0.15.10", features = [
+  "windows-console-colors",
+], optional = true }
+serde = "1.0.217"
+thiserror = "2.0.11"
+toml = "0.8"
+
+[dependencies.serde_json]
+version = "1.0.135"
+features = ["indexmap", "preserve_order", "raw_value", "unbounded_depth"]
+optional = true
+
+[features]
+default = ["bin", "json"]
+bin = ["dep:anyhow", "dep:clap"]
+# THIS FEATURE IS FOR THE PREVIOUS VERSION OF TOMLQ AND IS NOT USED BY THE TQ BINARY.
+# IT WILL BE REMOVED IN A FUTURE RELEASE.
+color = ["dep:colored"]
+json = ["dep:serde_json"]
+# Syntax highlighting feature for the tq CLI -- optional, disabled by default.
+syntax-highlighting = ["bin", "dep:bat", "dep:console"]
+
 [profile.release]
-strip = true
 opt-level = "z"
+strip = true
 lto = true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The current iteration of this crate supports both the `tq` and `tomlq` binaries.
 - Using `cargo` (compiles from source): `cargo install tomlq`
 - Using `cargo-binstall` (downloads from Github Releases page): `cargo binstall -y tomlq`
 
+Pre-built binaries are available for Linux (amd64, arm64, armv7) and macOS (Apple Silicon, Intel).
+
 ## Migrating from `tq-rs` crate
 
 The only step that is required to migrate from `tq-rs` to `tomlq` is to change the `cargo install` (or `cargo binstall`) step from referencing `tq-rs` to referencing `tomlq`. The binary has the same name, and the usage is the same.


### PR DESCRIPTION
Adds macOS binary builds to both the CI build and release workflows.

## Changes

- **build.yaml**: Split `build-binary` into `build-linux` and `build-macos` jobs
- **release.yaml**: Same split, plus macOS artifacts get packaged as `.tgz` and uploaded alongside Linux builds
- **Cargo.toml**: Added `binstall` overrides for `aarch64-apple-darwin` and `x86_64-apple-darwin`
- **README.md**: Note about macOS binary availability

## Targets

| Target | Runner | Artifact name |
|--------|--------|---------------|
| `aarch64-apple-darwin` | `macos-latest` | `tomlq.darwin-arm64.tgz` |
| `x86_64-apple-darwin` | `macos-13` | `tomlq.darwin-amd64.tgz` |

Uses native macOS runners (no cross-compilation needed). `macos-13` for x86_64 since `macos-latest` is arm64-only.